### PR TITLE
Add draft of daily appointment selection screen

### DIFF
--- a/lib/views/mentor/mentorscreen.dart
+++ b/lib/views/mentor/mentorscreen.dart
@@ -44,15 +44,15 @@ class _MentorScreenState extends State<MentorScreen> {
         items: const <BottomNavigationBarItem>[
           BottomNavigationBarItem(
             icon: Icon(Icons.home),
-            title: Text("Home"),
+            label: 'Home',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.people),
-            title: Text("My Mentor"),
+            label: 'My Mentee',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.folder),
-            title: Text("Resources"),
+            label: 'Resources',
           ),
         ],
         currentIndex: _selectedIndex,

--- a/lib/views/student/bookappointment.dart
+++ b/lib/views/student/bookappointment.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+/*FIXME: This is a global variable to represent a list of already taken times.
+  Will want to replace with database call
+ */
+List<String> alreadyTakenTimes = ['10:00 AM', '1:00 PM'];
+
+//Very simple, checks to see if "time" is in "takenTimes", and gives you a red or green color back
+Color getAppointmentStatusColor(String time, List takenTimes) {
+  if (takenTimes.contains(time)) {
+    return Colors.redAccent;
+  }
+  return Color.fromRGBO(75, 209, 160, 1);
+}
+
+//Send in start of availability, end of availability, and appointment duration for an interable of appointment times
+Iterable<TimeOfDay> getTimes(
+    TimeOfDay startTime, TimeOfDay endTime, Duration step) sync* {
+  var hour = startTime.hour;
+  var minute = startTime.minute;
+
+  do {
+    yield TimeOfDay(hour: hour, minute: minute);
+    minute += step.inMinutes;
+    while (minute >= 60) {
+      minute -= 60;
+      hour++;
+    }
+  } while (hour < endTime.hour ||
+      (hour == endTime.hour && minute <= endTime.minute));
+}
+
+ListView getAppointmentListView(BuildContext context) {
+  //Hardcoded example start/end/duration values
+  final startTime = TimeOfDay(hour: 9, minute: 0);
+  final endTime = TimeOfDay(hour: 19, minute: 0);
+  final step = Duration(minutes: 30);
+
+  //Boilerplate code to convert to a list of strings
+  final times = getTimes(startTime, endTime, step)
+      .map((tod) => tod.format(context))
+      .toList();
+
+  return ListView.builder(
+    itemCount: times.length,
+    itemBuilder: (context, index) {
+      return Card(
+        child: InkWell(
+          splashColor: Color.fromRGBO(75, 209, 160, 1).withAlpha(30),
+          onTap: () => print('You clikced ${times[index]}'),
+          child: ListTile(
+            leading: CircleAvatar(
+              backgroundColor:
+                  getAppointmentStatusColor(times[index], alreadyTakenTimes),
+              maxRadius: 20,
+            ),
+            title: Text(
+              'Zoom Meeting',
+              style: TextStyle(
+                fontFamily: 'Montserrat',
+                fontWeight: FontWeight.bold,
+                fontSize: 17.0,
+              ),
+            ),
+            subtitle: Text('Link will be emailed to you'),
+            trailing: Text(
+              '${times[index]}',
+              style: TextStyle(
+                fontFamily: 'Montserrat',
+                fontWeight: FontWeight.bold,
+                fontSize: 17.0,
+              ),
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class AppointmentListPage extends StatefulWidget {
+  @override
+  _AppointmentListPageState createState() => _AppointmentListPageState();
+}
+
+class _AppointmentListPageState extends State<AppointmentListPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: SafeArea(child: getAppointmentListView(context)),
+    );
+  }
+}

--- a/lib/views/student/bookappointment.dart
+++ b/lib/views/student/bookappointment.dart
@@ -31,7 +31,7 @@ Iterable<TimeOfDay> getTimes(
       (hour == endTime.hour && minute <= endTime.minute));
 }
 
-ListView getAppointmentListView(BuildContext context) {
+ListView getDailyAppointmentListView(BuildContext context) {
   //Hardcoded example start/end/duration values
   final startTime = TimeOfDay(hour: 9, minute: 0);
   final endTime = TimeOfDay(hour: 19, minute: 0);
@@ -48,7 +48,7 @@ ListView getAppointmentListView(BuildContext context) {
       return Card(
         child: InkWell(
           splashColor: Color.fromRGBO(75, 209, 160, 1).withAlpha(30),
-          onTap: () => print('You clikced ${times[index]}'),
+          onTap: () => print('You clicked ${times[index]}'),
           child: ListTile(
             leading: CircleAvatar(
               backgroundColor:
@@ -56,14 +56,13 @@ ListView getAppointmentListView(BuildContext context) {
               maxRadius: 20,
             ),
             title: Text(
-              'Zoom Meeting',
+              'November 17th, 2020',
               style: TextStyle(
                 fontFamily: 'Montserrat',
                 fontWeight: FontWeight.bold,
                 fontSize: 17.0,
               ),
             ),
-            subtitle: Text('Link will be emailed to you'),
             trailing: Text(
               '${times[index]}',
               style: TextStyle(
@@ -89,7 +88,7 @@ class _AppointmentListPageState extends State<AppointmentListPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: SafeArea(child: getAppointmentListView(context)),
+      body: SafeArea(child: getDailyAppointmentListView(context)),
     );
   }
 }

--- a/lib/views/student/bookappointment.dart
+++ b/lib/views/student/bookappointment.dart
@@ -14,6 +14,7 @@ Color getAppointmentStatusColor(String time, List takenTimes) {
 }
 
 //Send in start of availability, end of availability, and appointment duration for an interable of appointment times
+//Credit for this function: https://stackoverflow.com/questions/60370798/how-to-create-30-minutes-time-slots-in-flutter-dart
 Iterable<TimeOfDay> getTimes(
     TimeOfDay startTime, TimeOfDay endTime, Duration step) sync* {
   var hour = startTime.hour;

--- a/lib/views/student/mymentor.dart
+++ b/lib/views/student/mymentor.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'bookappointment.dart';
 
 class MyMentorScreen extends StatelessWidget {
   final List<QueryDocumentSnapshot> mentorList;
@@ -30,7 +31,10 @@ class MentorProfileCard extends StatelessWidget {
       child: InkWell(
         splashColor: Color.fromRGBO(75, 209, 160, 1).withAlpha(30),
         onTap: () {
-          print('Card tapped.');
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => AppointmentListPage()),
+          );
         },
         child: Container(
           height: 250,

--- a/lib/views/student/studentscreen.dart
+++ b/lib/views/student/studentscreen.dart
@@ -50,15 +50,15 @@ class _StudentScreenState extends State<StudentScreen> {
         items: const <BottomNavigationBarItem>[
           BottomNavigationBarItem(
             icon: Icon(Icons.home),
-            title: Text("Home"),
+            label: 'Home',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.people),
-            title: Text("My Mentor"),
+            label: 'My Mentor',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.folder),
-            title: Text("Resources"),
+            label: 'Resources',
           ),
         ],
         currentIndex: _selectedIndex,


### PR DESCRIPTION
Given mentor availability and duration of appointment, we can generate a listview of appointment tiles. As a bonus, we can compare against a list of times that are already taken and mark the taken times with a red circle instead of a friendly green circle.

Note: each mentor card now only takes you to the same appointment screen. Here's what remains to be done with it:

- When you click on a mentor card, populate appointments with that mentor's availability from database call
- Create pop up window on tapping an appointment that confirms that you want to reserve appointment
- Send info to database upon confirming appointment

![screen](https://user-images.githubusercontent.com/48846148/99436246-d9f8b680-28d6-11eb-8e8f-37833c1312d1.png)